### PR TITLE
Trigger backport workflow on comment

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,14 +1,24 @@
-name: Backport PRs after merge
+name: Backport labeled merged pull requests
 on:
   pull_request:
     types: [ closed ]
+  issue_comment:
+    types: [ created ]
 jobs:
   build:
     name: Create backport PRs
+    if: >
+      github.event_name == 'pull_request' ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '/backport')
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
+          # required to find all branches
           fetch-depth: 0
       - name: Create backport PRs
         uses: zeebe-io/backport-action@master


### PR DESCRIPTION
Applies the latest example from the backport-action README, to enable triggering the backport action by writing a comment. 