### PR TITLE
remove unnecessary prerequisites

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,10 +21,6 @@
     <tag>HEAD</tag>
   </scm>
 
-  <prerequisites>
-    <maven>${maven.version}</maven>
-  </prerequisites>
-
   <parent>
     <groupId>org.camunda.community</groupId>
     <artifactId>community-hub-release-parent</artifactId>


### PR DESCRIPTION
The maven prerequisities are only supported for building maven plugin's. It will cause warning on build time on normal projects.

Warning:

```
[INFO] Scanning for projects...
[WARNING] The project org.apache.maven:maven:pom:3.5.0 uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html
```

See here https://maven.apache.org/docs/3.5.0/release-notes.html 