### PR TITLE
add empty relative path to parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
     <groupId>org.camunda.community</groupId>
     <artifactId>community-hub-release-parent</artifactId>
     <version>1.0.0</version>
+    <relativePath />
   </parent>
 
   <properties>


### PR DESCRIPTION
An empty relative path tag should be used if we not look up the parent locally.

https://robintegg.com/2019/01/20/why-does-spring-initializr-set-the-parent-pom-relativepath-to-empty.html

Related PR https://github.com/camunda-community-hub/community-hub-release-parent/pull/3