### PR TITLE
Bump backport-action to v1

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -21,27 +21,4 @@ jobs:
       )
     steps:
       - uses: actions/checkout@v3
-      - name: Create backport PRs
-        uses: zeebe-io/backport-action@v0.0.7
-        with:
-          # Required
-          # Token to authenticate requests to GitHub
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-          # Required
-          # Working directory for the backport action
-          github_workspace: ${{ github.workspace }}
-
-          # Optional
-          # Regex pattern to match github labels
-          # Must contain a capture group for the target branch
-          # label_pattern: ^backport ([^ ]+)$
-
-          # Optional
-          # Template used as description in the pull requests created by this action.
-          # Placeholders can be used to define variable values.
-          # These are indicated by a dollar sign and curly braces (`${placeholder}`).
-          # Please refer to this action's README for all available placeholders.
-          # pull_description: |-
-          #   # Description
-          #   Backport of #${pull_number} to `${target_branch}`.
+      - uses: korthout/backport-action@v1

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Empty maven project with defaults that incorporates Camunda Community Hub best p
   - https://editorconfig.org/
 - GitHub Integration
   - Dependabot enabled for Maven dependencies
-  - Backport action (https://github.com/zeebe-io/backport-action)
+  - Backport action (https://github.com/korthout/backport-action)
 - Maven POM
   - Release to Maven, Nexus and GitHub
   - Google Code Formatter


### PR DESCRIPTION
The latest version no longer requires any inputs and offers a tag for the latest major release `v1` so users don't have to try to keep it up to date.

Please note that the repo has moved from [`zeebe-io/backport-action`](https://github.com/zeebe-io/backport-action) to [`korthout/backport-action`](https://github.com/korthout/backport-action).